### PR TITLE
use quotes when defining background image url

### DIFF
--- a/src/Magnifier.tsx
+++ b/src/Magnifier.tsx
@@ -252,7 +252,7 @@ export default class Magnifier extends PureComponent<Props, State> {
 							height: mgHeight,
 							left: `calc(${relX * 100}% - ${mgWidth / 2}px + ${mgOffsetX}px - ${mgBorderWidth}px)`,
 							top: `calc(${relY * 100}% - ${mgHeight / 2}px + ${mgOffsetY}px - ${mgBorderWidth}px)`,
-							backgroundImage: `url(${zoomImgSrc || src})`,
+							backgroundImage: `url("${zoomImgSrc || src}")`,
 							backgroundPosition: `calc(${relX * 100}% + ${mgWidth / 2}px - ${relX *
 								mgWidth}px) calc(${relY * 100}% + ${mgHeight / 2}px - ${relY * mgWidth}px)`,
 							backgroundSize: `${zoomFactor * this.imgBounds.width}% ${zoomFactor *


### PR DESCRIPTION
If an image url is used containing a space at any place in the path, the magnifier itself doesn't work and stays grey.
While a space in a path is not a problem at all, the bug occurs because the css property `background-image` isn't defined with quotation marks like it [should be](https://developer.mozilla.org/de/docs/Web/CSS/background-image), which results in an invalid css rule. 

This pull request resolves that issue by always encapsulating the image path in quotation marks.