### PR TITLE
add ability to pass alt and style props down to img with typescript

### DIFF
--- a/src/Magnifier.tsx
+++ b/src/Magnifier.tsx
@@ -2,7 +2,7 @@ import "./style.scss";
 
 import debounce from "lodash.debounce";
 import throttle from "lodash.throttle";
-import React, { PureComponent } from "react";
+import React, { CSSProperties, PureComponent } from "react";
 
 type mgShape = "circle" | "square";
 
@@ -12,6 +12,8 @@ interface Props {
 	width: string | number;
 	height: string | number;
 	className: string;
+	alt: string | undefined;
+	style: CSSProperties | undefined;
 
 	// Zoom image
 	zoomImgSrc: string;
@@ -53,6 +55,8 @@ export default class Magnifier extends PureComponent<Props, State> {
 		width: "100%",
 		height: "auto",
 		className: "",
+		alt: undefined,
+		style: undefined,
 
 		// Zoom image
 		zoomImgSrc: "",


### PR DESCRIPTION
## summary
fixes 👇 
<img width="926" alt="Screen Shot 2020-09-11 at 2 08 39 PM" src="https://user-images.githubusercontent.com/16400333/92973804-b9753180-f439-11ea-9f25-fb3d210a6991.png">

## tests
ran `npm run build` and `npm start:storybook` with success